### PR TITLE
Fix function typo and pep8

### DIFF
--- a/src/piper/launch/start_single_piper.launch.py
+++ b/src/piper/launch/start_single_piper.launch.py
@@ -3,6 +3,7 @@ from launch_ros.actions import Node
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 
+
 def generate_launch_description():
     # Declare the launch arguments
     can_port_arg = DeclareLaunchArgument(
@@ -15,13 +16,13 @@ def generate_launch_description():
         default_value='true',
         description='Automatically enable the Piper node.'
     )
-    
+
     rviz_ctrl_flag_arg = DeclareLaunchArgument(
         'rviz_ctrl_flag',
         default_value='false',
         description='Start rviz flag.'
     )
-    
+
     girpper_exist_arg = DeclareLaunchArgument(
         'girpper_exist',
         default_value='true',

--- a/src/piper/launch/start_single_piper_rviz.launch.py
+++ b/src/piper/launch/start_single_piper_rviz.launch.py
@@ -11,6 +11,7 @@ from ament_index_python.packages import get_package_share_directory
 
 import os
 
+
 def generate_launch_description():
     # 获取piper_description包的路径
     piper_description_path = os.path.join(
@@ -42,13 +43,13 @@ def generate_launch_description():
         default_value='true',
         description='Start rviz flag.'
     )
-    
+
     girpper_exist_arg = DeclareLaunchArgument(
         'girpper_exist',
         default_value='true',
         description='gripper'
     )
-    
+
     # 定义机械臂节点
     piper_ctrl_node = Node(
         package='piper',
@@ -58,8 +59,8 @@ def generate_launch_description():
         parameters=[
             {'can_port': LaunchConfiguration('can_port')},
             {'auto_enable': LaunchConfiguration('auto_enable')},
-            {'rviz_ctrl_flag':  LaunchConfiguration('rviz_ctrl_flag')},
-            {'girpper_exist':  LaunchConfiguration('girpper_exist')}
+            {'rviz_ctrl_flag': LaunchConfiguration('rviz_ctrl_flag')},
+            {'girpper_exist': LaunchConfiguration('girpper_exist')}
         ],
         remappings=[
             ('joint_ctrl_single', '/joint_states')

--- a/src/piper/piper/piper_ctrl_single_node.py
+++ b/src/piper/piper/piper_ctrl_single_node.py
@@ -108,11 +108,11 @@ class C_PiperRosNode(Node):
             if(elapsed_time_flag):
                 print("程序自动使能超时,退出程序")
                 exit(0)
-            
+
             self.PublishArmState()
             self.PublishArmJointAndGirpper()
-            self.PubilsArmEndPose()
-            
+            self.PublishArmEndPose()
+
             rate.sleep()
 
     def PublishArmState(self):
@@ -161,8 +161,8 @@ class C_PiperRosNode(Node):
         self.joint_states.velocity = [vel_0, vel_1, vel_2, vel_3, vel_4, vel_5, 0.0]  # Example values
         self.joint_states.effort = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, effort_6]
         self.joint_pub.publish(self.joint_states)
-    
-    def PubilsArmEndPose(self):
+
+    def PublishArmEndPose(self):
         # 末端位姿
         endpos = Pose()
         endpos.position.x = self.piper.GetArmEndPoseMsgs().end_pose.X_axis/1000000

--- a/src/piper/piper/piper_ctrl_single_node.py
+++ b/src/piper/piper/piper_ctrl_single_node.py
@@ -1,26 +1,23 @@
 #!/usr/bin/env python3
 # -*-coding:utf8-*-
 # 本文件为控制单个机械臂节点，控制夹爪机械臂运动
-from typing import (
-    Optional,
-)
 import rclpy
 from rclpy.node import Node
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Bool
 import time
 import threading
-import argparse
-from piper_sdk import *
 from piper_sdk import C_PiperInterface
 from piper_msgs.msg import PiperStatusMsg, PosCmd
-from piper_msgs.srv  import Enable
+from piper_msgs.srv import Enable
 from geometry_msgs.msg import Pose
 from scipy.spatial.transform import Rotation as R  # 用于欧拉角到四元数的转换
+
 
 class C_PiperRosNode(Node):
     """机械臂ros2节点
     """
+
     def __init__(self) -> None:
         super().__init__('piper_ctrl_single_node')
         # 外部param参数
@@ -61,7 +58,7 @@ class C_PiperRosNode(Node):
         self.create_subscription(PosCmd, 'pos_cmd', self.pos_callback, 10)
         self.create_subscription(JointState, 'joint_ctrl_single', self.joint_callback, 10)
         self.create_subscription(Bool, 'enable_flag', self.enable_callback, 10)
-        
+
         self.publisher_thread = threading.Thread(target=self.publish_thread)
         self.publisher_thread.start()
 
@@ -91,9 +88,9 @@ class C_PiperRosNode(Node):
                         self.piper.GetArmLowSpdInfoMsgs().motor_4.foc_status.driver_enable_status and \
                         self.piper.GetArmLowSpdInfoMsgs().motor_5.foc_status.driver_enable_status and \
                         self.piper.GetArmLowSpdInfoMsgs().motor_6.foc_status.driver_enable_status
-                    print("使能状态:",enable_flag)
+                    print("使能状态:", enable_flag)
                     self.piper.EnableArm(7)
-                    self.piper.GripperCtrl(0,1000,0x01, 0)
+                    self.piper.GripperCtrl(0, 1000, 0x01, 0)
                     if(enable_flag):
                         self.__enable_flag = True
                     print("--------------------")
@@ -137,27 +134,27 @@ class C_PiperRosNode(Node):
         arm_status.communication_status_joint_5 = self.piper.GetArmStatus().arm_status.err_status.communication_status_joint_5
         arm_status.communication_status_joint_6 = self.piper.GetArmStatus().arm_status.err_status.communication_status_joint_6
         self.arm_status_pub.publish(arm_status)
-    
+
     def PublishArmJointAndGirpper(self):
         # 赋值时间戳
         self.joint_states.header.stamp = self.get_clock().now().to_msg()
         # Here, you can set the joint positions to any value you want
         # 由于获取的原始数据是度为单位扩大了1000倍，因此要转为弧度需要先除以1000，再乘3.14/180，然后限制小数点位数为5位
-        joint_0:float = (self.piper.GetArmJointMsgs().joint_state.joint_1/1000) * 0.017444
-        joint_1:float = (self.piper.GetArmJointMsgs().joint_state.joint_2/1000) * 0.017444
-        joint_2:float = (self.piper.GetArmJointMsgs().joint_state.joint_3/1000) * 0.017444
-        joint_3:float = (self.piper.GetArmJointMsgs().joint_state.joint_4/1000) * 0.017444
-        joint_4:float = (self.piper.GetArmJointMsgs().joint_state.joint_5/1000) * 0.017444
-        joint_5:float = (self.piper.GetArmJointMsgs().joint_state.joint_6/1000) * 0.017444
-        joint_6:float = self.piper.GetArmGripperMsgs().gripper_state.grippers_angle/1000000
-        vel_0:float = self.piper.GetArmHighSpdInfoMsgs().motor_1.motor_speed/1000
-        vel_1:float = self.piper.GetArmHighSpdInfoMsgs().motor_2.motor_speed/1000
-        vel_2:float = self.piper.GetArmHighSpdInfoMsgs().motor_3.motor_speed/1000
-        vel_3:float = self.piper.GetArmHighSpdInfoMsgs().motor_4.motor_speed/1000
-        vel_4:float = self.piper.GetArmHighSpdInfoMsgs().motor_5.motor_speed/1000
-        vel_5:float = self.piper.GetArmHighSpdInfoMsgs().motor_6.motor_speed/1000
-        effort_6:float = self.piper.GetArmGripperMsgs().gripper_state.grippers_effort/1000
-        self.joint_states.position = [joint_0,joint_1, joint_2, joint_3, joint_4, joint_5,joint_6]  # Example values
+        joint_0: float = (self.piper.GetArmJointMsgs().joint_state.joint_1 / 1000) * 0.017444
+        joint_1: float = (self.piper.GetArmJointMsgs().joint_state.joint_2 / 1000) * 0.017444
+        joint_2: float = (self.piper.GetArmJointMsgs().joint_state.joint_3 / 1000) * 0.017444
+        joint_3: float = (self.piper.GetArmJointMsgs().joint_state.joint_4 / 1000) * 0.017444
+        joint_4: float = (self.piper.GetArmJointMsgs().joint_state.joint_5 / 1000) * 0.017444
+        joint_5: float = (self.piper.GetArmJointMsgs().joint_state.joint_6 / 1000) * 0.017444
+        joint_6: float = self.piper.GetArmGripperMsgs().gripper_state.grippers_angle / 1000000
+        vel_0: float = self.piper.GetArmHighSpdInfoMsgs().motor_1.motor_speed / 1000
+        vel_1: float = self.piper.GetArmHighSpdInfoMsgs().motor_2.motor_speed / 1000
+        vel_2: float = self.piper.GetArmHighSpdInfoMsgs().motor_3.motor_speed / 1000
+        vel_3: float = self.piper.GetArmHighSpdInfoMsgs().motor_4.motor_speed / 1000
+        vel_4: float = self.piper.GetArmHighSpdInfoMsgs().motor_5.motor_speed / 1000
+        vel_5: float = self.piper.GetArmHighSpdInfoMsgs().motor_6.motor_speed / 1000
+        effort_6: float = self.piper.GetArmGripperMsgs().gripper_state.grippers_effort / 1000
+        self.joint_states.position = [joint_0, joint_1, joint_2, joint_3, joint_4, joint_5, joint_6]  # Example values
         self.joint_states.velocity = [vel_0, vel_1, vel_2, vel_3, vel_4, vel_5, 0.0]  # Example values
         self.joint_states.effort = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, effort_6]
         self.joint_pub.publish(self.joint_states)
@@ -165,19 +162,19 @@ class C_PiperRosNode(Node):
     def PublishArmEndPose(self):
         # 末端位姿
         endpos = Pose()
-        endpos.position.x = self.piper.GetArmEndPoseMsgs().end_pose.X_axis/1000000
-        endpos.position.y = self.piper.GetArmEndPoseMsgs().end_pose.Y_axis/1000000
-        endpos.position.z = self.piper.GetArmEndPoseMsgs().end_pose.Z_axis/1000000
-        roll = self.piper.GetArmEndPoseMsgs().end_pose.RX_axis/1000
-        pitch = self.piper.GetArmEndPoseMsgs().end_pose.RY_axis/1000
-        yaw = self.piper.GetArmEndPoseMsgs().end_pose.RZ_axis/1000
+        endpos.position.x = self.piper.GetArmEndPoseMsgs().end_pose.X_axis / 1000000
+        endpos.position.y = self.piper.GetArmEndPoseMsgs().end_pose.Y_axis / 1000000
+        endpos.position.z = self.piper.GetArmEndPoseMsgs().end_pose.Z_axis / 1000000
+        roll = self.piper.GetArmEndPoseMsgs().end_pose.RX_axis / 1000
+        pitch = self.piper.GetArmEndPoseMsgs().end_pose.RY_axis / 1000
+        yaw = self.piper.GetArmEndPoseMsgs().end_pose.RZ_axis / 1000
         quaternion = R.from_euler('xyz', [roll, pitch, yaw]).as_quat()
         endpos.orientation.x = quaternion[0]
         endpos.orientation.y = quaternion[1]
         endpos.orientation.z = quaternion[2]
         endpos.orientation.w = quaternion[3]
         self.end_pose_pub.publish(endpos)
-    
+
     def pos_callback(self, pos_data):
         """机械臂末端位姿订阅回调函数
 
@@ -194,31 +191,33 @@ class C_PiperRosNode(Node):
         self.get_logger().info(f"gripper: {pos_data.gripper}")
         self.get_logger().info(f"mode1: {pos_data.mode1}")
         self.get_logger().info(f"mode2: {pos_data.mode2}")
-        x = round(pos_data.x*1000)
-        y = round(pos_data.y*1000)
-        z = round(pos_data.z*1000)
-        rx = round(pos_data.roll*1000)
-        ry = round(pos_data.pitch*1000)
-        rz = round(pos_data.yaw*1000)
+        x = round(pos_data.x * 1000)
+        y = round(pos_data.y * 1000)
+        z = round(pos_data.z * 1000)
+        rx = round(pos_data.roll * 1000)
+        ry = round(pos_data.pitch * 1000)
+        rz = round(pos_data.yaw * 1000)
         if(self.GetEnableFlag()):
             self.piper.MotionCtrl_1(0x00, 0x00, 0x00)
             self.piper.MotionCtrl_2(0x01, 0x02, 50)
-            self.piper.EndPoseCtrl(x, y, z, 
-                                    rx, ry, rz)
-            gripper = round(pos_data.gripper*1000*1000)
-            if(pos_data.gripper>80000): gripper = 80000
-            if(pos_data.gripper<0): gripper = 0
+            self.piper.EndPoseCtrl(x, y, z,
+                                   rx, ry, rz)
+            gripper = round(pos_data.gripper * 1000 * 1000)
+            if(pos_data.gripper > 80000):
+                gripper = 80000
+            if(pos_data.gripper < 0):
+                gripper = 0
             if(self.girpper_exist):
                 self.piper.GripperCtrl(abs(gripper), 1000, 0x01, 0)
             self.piper.MotionCtrl_2(0x01, 0x00, 50)
-    
+
     def joint_callback(self, joint_data):
         """机械臂关节角回调函数
 
         Args:
             joint_data (): 
         """
-        factor = 57324.840764 #1000*180/3.14
+        factor = 57324.840764  # 1000*180/3.14
         factor1 = 57.32484
         self.get_logger().info(f"Received Joint States:")
         self.get_logger().info(f"joint_0: {joint_data.position[0]}")
@@ -228,28 +227,33 @@ class C_PiperRosNode(Node):
         self.get_logger().info(f"joint_4: {joint_data.position[4]}")
         self.get_logger().info(f"joint_5: {joint_data.position[5]}")
         self.get_logger().info(f"joint_6: {joint_data.position[6]}")
-        joint_0 = round(joint_data.position[0]*factor)
-        joint_1 = round(joint_data.position[1]*factor)
-        joint_2 = round(joint_data.position[2]*factor)
-        joint_3 = round(joint_data.position[3]*factor)
-        joint_4 = round(joint_data.position[4]*factor)
-        joint_5 = round(joint_data.position[5]*factor)
-        joint_6 = round(joint_data.position[6]*1000*1000)
+        joint_0 = round(joint_data.position[0] * factor)
+        joint_1 = round(joint_data.position[1] * factor)
+        joint_2 = round(joint_data.position[2] * factor)
+        joint_3 = round(joint_data.position[3] * factor)
+        joint_4 = round(joint_data.position[4] * factor)
+        joint_5 = round(joint_data.position[5] * factor)
+        joint_6 = round(joint_data.position[6] * 1000 * 1000)
         if(self.rviz_ctrl_flag):
             joint_6 = joint_6 * 2
-        if(joint_6>80000): joint_6 = 80000
-        if(joint_6<0): joint_6 = 0
+        if(joint_6 > 80000):
+            joint_6 = 80000
+        if(joint_6 < 0):
+            joint_6 = 0
         if(self.GetEnableFlag()):
             # 设定电机速度
             if(joint_data.velocity != []):
                 all_zeros = all(v == 0 for v in joint_data.velocity)
-            else: all_zeros = True
+            else:
+                all_zeros = True
             if(not all_zeros):
                 lens = len(joint_data.velocity)
                 if(lens == 7):
                     vel_all = round(joint_data.velocity[6])
-                    if (vel_all > 100): vel_all = 100
-                    if (vel_all < 0): vel_all = 0
+                    if (vel_all > 100):
+                        vel_all = 100
+                    if (vel_all < 0):
+                        vel_all = 0
                     self.get_logger().info(f"vel_all: {vel_all}")
                     self.piper.MotionCtrl_2(0x01, 0x01, vel_all)
                 # elif(lens == 7):
@@ -259,26 +263,31 @@ class C_PiperRosNode(Node):
                 #             # 设置指定位置的关节速度为这个正数速度
                 #             # self.piper.SearchMotorMaxAngleSpdAccLimit(i+1,0x01)
                 #             # self.piper.MotorAngleLimitMaxSpdSet(i+1)
-                else: self.piper.MotionCtrl_2(0x01, 0x01, 30)
-            else: self.piper.MotionCtrl_2(0x01, 0x01, 30)
-            self.piper.JointCtrl(joint_0, joint_1, joint_2, 
-                                    joint_3, joint_4, joint_5)
+                else:
+                    self.piper.MotionCtrl_2(0x01, 0x01, 30)
+            else:
+                self.piper.MotionCtrl_2(0x01, 0x01, 30)
+            self.piper.JointCtrl(joint_0, joint_1, joint_2,
+                                 joint_3, joint_4, joint_5)
             if(self.girpper_exist):
                 if(len(joint_data.effort) == 7):
                     gripper_effort = joint_data.effort[6]
-                    if (gripper_effort > 3): gripper_effort = 3
-                    if (gripper_effort < 0.5): gripper_effort = 0.5
+                    if (gripper_effort > 3):
+                        gripper_effort = 3
+                    if (gripper_effort < 0.5):
+                        gripper_effort = 0.5
                     self.get_logger().info(f"gripper_effort: {gripper_effort}")
-                    gripper_effort = round(gripper_effort*1000)
+                    gripper_effort = round(gripper_effort * 1000)
                     self.piper.GripperCtrl(abs(joint_6), gripper_effort, 0x01, 0)
                 # 默认1N
-                else: self.piper.GripperCtrl(abs(joint_6), 1000, 0x01, 0)
-    
-    def enable_callback(self, enable_flag:Bool):
+                else:
+                    self.piper.GripperCtrl(abs(joint_6), 1000, 0x01, 0)
+
+    def enable_callback(self, enable_flag: Bool):
         """机械臂使能回调函数
 
         Args:
-            enable_flag (): 
+            enable_flag ():
         """
         self.get_logger().info(f"Received enable flag:")
         self.get_logger().info(f"enable_flag: {enable_flag.data}")
@@ -286,12 +295,12 @@ class C_PiperRosNode(Node):
             self.__enable_flag = True
             self.piper.EnableArm(7)
             if(self.girpper_exist):
-                self.piper.GripperCtrl(0,1000,0x01, 0)
+                self.piper.GripperCtrl(0, 1000, 0x01, 0)
         else:
             self.__enable_flag = False
             self.piper.DisableArm(7)
             if(self.girpper_exist):
-                self.piper.GripperCtrl(0,1000,0x00, 0)
+                self.piper.GripperCtrl(0, 1000, 0x00, 0)
 
     def handle_enable_service(self, req, resp):
         self.get_logger().info(f"Received request:: {req.enable_request}")
@@ -301,7 +310,6 @@ class C_PiperRosNode(Node):
         timeout = 5
         # 记录进入循环前的时间
         start_time = time.time()
-        elapsed_time_flag = False
         while not (loop_flag):
             elapsed_time = time.time() - start_time
             self.get_logger().info(f"--------------------")
@@ -315,24 +323,23 @@ class C_PiperRosNode(Node):
             if(req.enable_request):
                 enable_flag = all(enable_list)
                 self.piper.EnableArm(7)
-                self.piper.GripperCtrl(0,1000,0x01, 0)
+                self.piper.GripperCtrl(0, 1000, 0x01, 0)
             else:
                 enable_flag = any(enable_list)
                 self.piper.DisableArm(7)
-                self.piper.GripperCtrl(0,1000,0x02, 0)
+                self.piper.GripperCtrl(0, 1000, 0x02, 0)
             self.get_logger().info(f"使能状态: {enable_flag}")
             self.__enable_flag = enable_flag
             self.get_logger().info(f"--------------------")
             if(enable_flag == req.enable_request):
                 loop_flag = True
                 enable_flag = True
-            else: 
+            else:
                 loop_flag = False
                 enable_flag = False
             # 检查是否超过超时时间
             if elapsed_time > timeout:
                 self.get_logger().info(f"超时....")
-                elapsed_time_flag = True
                 enable_flag = False
                 loop_flag = True
                 break
@@ -340,7 +347,8 @@ class C_PiperRosNode(Node):
         resp.enable_response = enable_flag
         self.get_logger().info(f"Returning response: {resp.enable_response}")
         return resp
-    
+
+
 def main(args=None):
     rclpy.init(args=args)
     piper_single_node = C_PiperRosNode()

--- a/src/piper/setup.py
+++ b/src/piper/setup.py
@@ -2,7 +2,6 @@ from setuptools import find_packages, setup
 import glob
 import sys
 import os
-from glob import glob
 
 package_name = 'piper'
 
@@ -16,7 +15,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        
+
         # 安装 launch 文件
         (os.path.join('share', package_name, 'launch'), glob('launch/*.py')),
         # 安装其他文件，如参数文件


### PR DESCRIPTION
`PubilsArmEndPose` -> `PublishArmEndPose`

* Remove unused imports
* Remove trailing whitespaces
* Fix tabs vs spaces
* Fix all style warnings (whitespace around `,` and `:` mostly)