### PR TITLE
 creating changes for C_PiperInterface

### DIFF
--- a/src/piper/scripts/piper_ctrl_single_node.py
+++ b/src/piper/scripts/piper_ctrl_single_node.py
@@ -77,7 +77,7 @@ class C_PiperRosNode():
         self.joint_states.effort = [0.0] * 7
         
         # 创建piper类并打开can接口
-        self.piper = C_PiperInterface(can_name=self.can_port)
+        self.piper = C_PiperInterface()
         self.piper.ConnectPort()
         self.piper.MotionCtrl_2(0x01, 0x01, 30,0)
 


### PR DESCRIPTION
### Fix for C_PiperInterface Initialization Issue
#### Summary

The piper_sdk has been updated, but the piper_ctrl/single_node.py script was not aligned with the latest changes. Specifically, the C_PiperInterface class was causing the following error during initialization:

`TypeError: __new__() got an unexpected keyword argument 'can_name'`

#### Changes Made

-   Modified single_node.py to ensure compatibility with the latest piper_sdk.
-   Tested the updated implementation, and it is now working as expected.

#### Impact

-   Fixes compatibility issues between piper_ctrl/single_node.py and the updated piper_sdk.
-   Ensures proper instantiation of C_PiperInterface.

#### Testing

-   Verified functionality after making the changes.
-   No errors encountered during initialization.