### PR TITLE
Fix typo in gripper_exist parameter name in launch files

### DIFF
--- a/src/piper/launch/start_single_piper.launch
+++ b/src/piper/launch/start_single_piper.launch
@@ -9,7 +9,7 @@
     <param name="auto_enable" value="$(arg auto_enable)" />
     <param name="gripper_val_mutiple" value="$(arg gripper_val_mutiple)" />
     <!-- <param name="rviz_ctrl_flag" value="true" /> -->
-    <param name="girpper_exist" value="true" />
+    <param name="gripper_exist" value="true" />
     <remap from="joint_ctrl_single" to="/joint_states" />
   </node>
 </launch>

--- a/src/piper/launch/start_single_piper_rviz.launch
+++ b/src/piper/launch/start_single_piper_rviz.launch
@@ -8,7 +8,7 @@
     <param name="auto_enable" value="$(arg auto_enable)" />
     <param name="gripper_val_mutiple" value="2" />
     <!-- <param name="rviz_ctrl_flag" value="true" /> -->
-    <param name="girpper_exist" value="true" />
+    <param name="gripper_exist" value="true" />
     <remap from="joint_ctrl_single" to="/joint_states" />
   </node>
 </launch>


### PR DESCRIPTION
### Summary
Fixed a critical typo in parameter names within launch files that was preventing the `gripper_exist` parameter from being properly passed to the control node.

### Problem Description
A typo was discovered in two launch files under `piper/launch/` directory:
1. `start_single_piper_rviz.launch`
2. `start_single_piper_.launch`

**Bug**: The parameter `gripper_exist` was incorrectly spelled as `girpper_exist` (extra 'r').

### Impact
1. **Parameter Failure**: Due to the misspelling, the `gripper_exist` parameter setting was completely ineffective
2. **Default Value Issue**: In `piper_ctrl_single_node.py`, this parameter defaults to `true`
3. **Critical Bug**: When running on hardware without a gripper, the program would use the default value `true`, causing:
   - Program crashes
   - Unexpected behavior
   - Hardware communication errors when trying to access non-existent gripper

### Reproduction Steps
1. Run launch files on robot hardware without a gripper
2. Set `gripper_exist:=false` (expected behavior)
3. Parameter fails to pass due to name mismatch
4. `piper_ctrl_single_node.py` uses default value `true`
5. Program attempts to access non-existent gripper hardware → Error/Crash

### Changes Made
- **Fixed**: `piper/launch/start_single_piper_rviz.launch`
- **Fixed**: `piper/launch/start_single_piper_.launch`
- **Change**: Renamed `girpper_exist` to `gripper_exist` in all param tags