### PR TITLE
fix(piper_ctrl_single_node): set frame_id for end pose stamp to "base_link"

### DIFF
--- a/src/piper/piper/piper_ctrl_single_node.py
+++ b/src/piper/piper/piper_ctrl_single_node.py
@@ -246,6 +246,7 @@ class PiperRosNode(Node):
         end_pos_stamp.pose = endpos
         end_pos_stamp.header.stamp = self.float_to_ros_time(new_time)
         # end_pos_stamp.header.stamp = self.get_clock().now().to_msg()
+        end_pos_stamp.header.frame_id = "base_link"
         self.end_pose_stamped_pub.publish(end_pos_stamp)
 
     def pos_callback(self, pos_data):


### PR DESCRIPTION
Set frame_id for end pose stamp to "base_link". It was empty previously.